### PR TITLE
Clarify optionality of `graph` argument to `@join__field`

### DIFF
--- a/join.spec.md
+++ b/join.spec.md
@@ -438,7 +438,7 @@ Specify the graph that can resolve the field.
 
 ```graphql definition
 directive @join__field(
-  graph: join__Graph!
+  graph: join__Graph
   requires: String
   provides: String
 ) on FIELD_DEFINITION
@@ -446,7 +446,7 @@ directive @join__field(
 
 The field's parent type MUST be annotated with a {@join__type} with the same value of `graph` as this directive, unless the parent type is a [root operation type](http://spec.graphql.org/draft/#sec-Root-Operation-Types).
 
-If a field is not annotated with {@join__field} and its parent type is annotated with `@join__owner(graph: G)`, then a processor MUST treat the field as if it is annotated with `@join__field(graph: G)`. If a field is not annotated with {@join__field} and its parent type is not annotated with {@join__owner} (ie, the parent type is a value type) then it MUST be resolvable in any subgraph that can resolve values of its parent type.
+If a field is not annotated with {@join__field} (or if the `graph` argument is not provided or `null`) and its parent type is annotated with `@join__owner(graph: G)`, then a processor MUST treat the field as if it is annotated with `@join__field(graph: G)`. If a field is not annotated with {@join__field} (or if the `graph` argument is not provided or `null`) and its parent type is not annotated with {@join__owner} (ie, the parent type is a value type) then it MUST be resolvable in any subgraph that can resolve values of its parent type.
 
 :::[example](photos.graphql#User...Image) -- Using {@join__field} to join fields to subgraphs
 


### PR DESCRIPTION
In other parts of the spec, `graph` is shown as a nullable argument, so we definitely need a change to make it consistent.

It seems reasonable to imagine that you might want to specify `@join__field(provides: "...")` on a value type or on an entity type where you're using the implicit ownership of the field based on the parent type's `@join__owner`, and the current version of printSupergraphSdl appears to allow this.