### PR TITLE
Add `@join__implements` directive and allow `@join__type` without `key`

### DIFF
--- a/join.spec.md
+++ b/join.spec.md
@@ -430,6 +430,21 @@ When this directive is placed on a type `T`, it means that subgraph `graph` MUST
 
 Every type with a {@join__type} MUST also have a [{@join__owner}](#@join__owner) directive. Any type with a [{@join__owner}](#@join__owner) directive MUST have at least one {@join__type} directive with the same `graph` as the [{@join__owner}](#@join__owner) directive (the "owning graph"), and MUST have at most one {@join__type} directive for each `graph` value other than the owning graph. Any value that appears as a `key` in a {@join__type} directive with a `graph` value other than the owning graph must also appear as a `key` in a {@join__type} directive with `graph` equal to the owning graph.
 
+##! @join__implements
+
+Declares that a type implements an interface in a particular subgraph.
+
+```graphql definition
+directive @join__implements(
+  graph: join__Graph!
+  interface: String!
+) repeatable on OBJECT | INTERFACE
+```
+
+When this directive is placed on a type `T`, it means that `T` implements the specified interface in subgraph `graph`. In that case, the referenced interface type MUST also be annotated with a {@join__type} with the same value of `graph` as this directive.
+
+This information MAY be used by the query planner to optimize requests to the subgraph.
+
 ##! @join__field
 
 Specify the graph that can resolve the field.

--- a/join.spec.md
+++ b/join.spec.md
@@ -413,16 +413,18 @@ The {@join__graph} directive MUST be applied to each enum value on {join__Graph}
 
 ##! @join__type
 
-Declares an entity key for a type on a subgraph.
+Declares that a type is known by a particular subgraph. Optionally, an entity key for the type on that subgraph may be specified.
 
 ```graphql definition
 directive @join__type(
   graph: join__Graph!
-  key: String!
+  key: String
 ) repeatable on OBJECT | INTERFACE
 ```
 
-When this directive is placed on a type `T`, it means that subgraph `graph` MUST be able to:
+When this directive is placed on a type `T`, it means that subgraph `graph` contains a definition for type `T`.
+
+If `key` is non-null, it means that subgraph `graph` MUST be able to:
 - Resolve selections on objects of the given type that contain the field set in `key`
 - Use `Query._entities` to resolve representations of objects containing `__typename: "T"` and the fields from the field set in `key`
 


### PR DESCRIPTION
This PR suggests some small changes to the spec to support generalized composition and the new query planning algorithm.

In particular, it allows `@join__type` to be used without specifying an entity key, which is needed to encode the idea of a subgraph containing a value type or defining a value interface.

It also adds `@join__implements` to allow composition and query planning to be aware of the interfaces implemented by a type in a particular subgraph.

Closes #13.

(As part of this, we may also want to remove `@join__owner` and the notion of ownership from the spec. But leaving that out for now.)